### PR TITLE
Add ping and extensions to faye_server default options.

### DIFF
--- a/lib/faye-rails/routing_hooks.rb
+++ b/lib/faye-rails/routing_hooks.rb
@@ -8,7 +8,9 @@ if defined? ActionDispatch::Routing
         defaults = {
           :mount => mount_path||'/faye',
           :timeout => 25,
+          :extensions => nil,
           :engine => nil,
+          :ping => nil,
           :server => 'thin'
         }
 


### PR DESCRIPTION
Faye::RackAdapter also accepts "ping and "extensions" as options:
[http://faye.jcoglan.com/ruby.html](http://faye.jcoglan.com/ruby.html)

Updated faye_server to accept them.
