### PR TITLE
Rails 4 route mapper compatibility

### DIFF
--- a/lib/faye-rails/routing_hooks.rb
+++ b/lib/faye-rails/routing_hooks.rb
@@ -28,7 +28,7 @@ if defined? ActionDispatch::Routing
         adapter = FayeRails::RackAdapter.new(options)
         adapter.instance_eval(&block) if block.respond_to? :call
 
-        get options[:mount] => adapter
+        match options[:mount] => adapter, via: :all
 
       end
 


### PR DESCRIPTION
Rails no longer supports routes that don't specify an HTTP verb (GET/POST).

See: http://rubysource.com/get-your-app-ready-for-rails-4/ 
https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/routing/mapper.rb#L62
