### PR TITLE
Backward-compatible Rails 4 route mapper compatibility

### DIFF
--- a/lib/faye-rails/routing_hooks.rb
+++ b/lib/faye-rails/routing_hooks.rb
@@ -28,7 +28,9 @@ if defined? ActionDispatch::Routing
         adapter = FayeRails::RackAdapter.new(options)
         adapter.instance_eval(&block) if block.respond_to? :call
 
-        match options[:mount] => adapter
+        match_options = {options[:mount] => adapter}
+        match_options.merge!(:via => :all) if Rails.version.to_i >= 4
+        match match_options
 
       end
 


### PR DESCRIPTION
There has been discussion in #42 of moving to a rack-based routing solution, but that has not been resolved, and Rails 4 is out now. This change would also require a major version bump, thus leaving 1.x incompatible with Rails 4.

This patch adds the required :via option for Rails >= version 4, but not for Rails 3, which does not support (nor need) :via.
