### PR TITLE
Remove references to deprecated Faye::RackAdapter#listen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,6 @@ config.middleware.use FayeRails::Middleware, mount: '/faye', :timeout => 25 do
 end
 ```
 
-If you really want to, you can ask Faye to start it's own listening Thin server on an arbitrary port:
-
-```ruby
-config.middleware.use FayeRails::Middleware, mount: '/faye', :timeout => 25 do
-  listen(9292)  
-end
-```
-
 You can also do some rudimentary routing using the map method:
 
 ```ruby

--- a/lib/faye-rails/rack_adapter.rb
+++ b/lib/faye-rails/rack_adapter.rb
@@ -10,15 +10,6 @@ module FayeRails
       FayeRails.servers << self
     end
 
-    def listen(port, ssl_options = nil)
-      if defined? ::Rails
-        Faye.ensure_reactor_running!
-        super
-      else
-        super
-      end
-    end
-
     # Rudimentary routing support for channels to controllers.
     #
     # @param opts


### PR DESCRIPTION
Faye::RackAdapter#listen is deprecated since faye 1.0.0, introduced by
81ecd3a9c388654f3d2249c040157e3cd653fb3c.

Deprecation was introduced by https://github.com/faye/faye/commit/c09913550cf616022aeabecf62b343fb32dff590